### PR TITLE
Add recipe for claude-code-emacs

### DIFF
--- a/recipes/claude-code
+++ b/recipes/claude-code
@@ -1,4 +1,4 @@
-(claude-code-emacs
+(claude-code
  :fetcher github
  :repo "yuya373/claude-code-emacs"
  :files (:defaults (:exclude "install-deps.el")))

--- a/recipes/claude-code-emacs
+++ b/recipes/claude-code-emacs
@@ -1,0 +1,3 @@
+(claude-code-emacs
+ :fetcher github
+ :repo "yuya373/claude-code-emacs")

--- a/recipes/claude-code-emacs
+++ b/recipes/claude-code-emacs
@@ -1,3 +1,4 @@
 (claude-code-emacs
  :fetcher github
- :repo "yuya373/claude-code-emacs")
+ :repo "yuya373/claude-code-emacs"
+ :files (:defaults (:exclude "install-deps.el")))


### PR DESCRIPTION
### Brief summary of what the package does

claude-code-emacs provides a seamless integration between Claude Code and Emacs. This package allows users to interact with Claude Code directly from Emacs, offering features like sending buffers/regions to Claude, managing conversations, and optionally supporting MCP (Model Context Protocol) for advanced editor integration.

### Direct link to the package repository

https://github.com/yuya373/claude-code-emacs

### Your association with the package

I am the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed - I am the maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)